### PR TITLE
Prevent browser from caching mapping_table.json in debug mode.

### DIFF
--- a/tslib/webgl/turbulenzengine.ts
+++ b/tslib/webgl/turbulenzengine.ts
@@ -14,6 +14,7 @@
 /// <reference path="inputdevice.ts" />
 /// <reference path="sounddevice.ts" />
 /// <reference path="graphicsdevice.ts" />
+/// <reference path="debug.ts" />
 
 interface Window
 {
@@ -391,6 +392,11 @@ class WebGLTurbulenzEngine implements TurbulenzEngine
                 xhr = null;
                 callback = null;
             }
+        }
+
+        if (!!debug)
+        {
+            url += "?" + Math.random().toString().substr(2);
         }
 
         xhr.open('GET', url, true);


### PR DESCRIPTION
Sorry for the ugly solution.

Request for a better one, because I don't understand the engine structure and TypeScript.
Maybe utilities.ts needs some modification too.
