### PR TITLE
change installing.rst for consistent virtualenv activate with installer

### DIFF
--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -209,7 +209,7 @@ prerequisites)
     In a terminal window, enter ::
 
         cd *SDKINSTALLDIR*
-        source env/bin/activate
+        source start_env
 
     You should see an **'(env)'** tag in front of your prompt.
 


### PR DESCRIPTION
Installer prints:

```
To activate the Turbulenz env (required to use the tools),
invoke the env setup script with a command of the form:

  source /Users/eren/Turbulenz/SDK/0.25.1/start_env
```

Doc change for consistency
