### PR TITLE
skeleton package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "Simon Moore <simonmoore@turbulenz.com>",
     "Vincent Briglia",
     "Adam Langridge <adamlangridge@turbulenz.com>",
-    "Chris Matthews <chrismatthews@turbulenz.com>",
+    "Chris Matthews <chrismatthews@turbulenz.com>"
   ],
   "license": "MIT",
-  "readmeFilename": "README.rst",
+  "readmeFilename": "README.rst"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "turbulenz_engine",
+  "version": "1.1.0",
+  "description": "modular 3D and 2D game framework for making HTML5 powered games for browsers and mobile devices",
+  "scripts": {
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/turbulenz/turbulenz_engine.git"
+  },
+  "contributors": [
+    "Blake Maltby <blakemaltby@turbulenz.com>",
+    "David Galeano <davidgaleano@turbulenz.com>",
+    "Duncan Tebbs <duncantebbs@turbulenz.com>",
+    "James Austin <jamesaustin@turbulenz.com>",
+    "Ian Ballantyne <ianballantyne@turbulenz.com>",
+    "David Fooks <davidfooks@turbulenz.com>",
+    "Ben Furneaux <benfurneaux@turbulenz.com>",
+    "James Long <jameslong@turbulenz.com>",
+    "Jan Borchers <janborchers@turbulenz.com>",
+    "Joe Kilner <joekilner@turbulenz.com>",
+    "Michael Braithwaite <michaelbraithwaite@turbulenz.com>",
+    "Sheheryar Zakaria",
+    "Simon Moore <simonmoore@turbulenz.com>",
+    "Vincent Briglia",
+    "Adam Langridge <adamlangridge@turbulenz.com>",
+    "Chris Matthews <chrismatthews@turbulenz.com>",
+  ],
+  "license": "MIT",
+  "readmeFilename": "README.rst",
+}


### PR DESCRIPTION
Basic beginning of package.json.

Anything further will probably require some re-structuring (like using [devDependencies](https://npmjs.org/doc/json.html#devDependencies) to track things like uglifyjs, instead of a sub-module, and [bin](https://npmjs.org/doc/json.html#bin) to track js cli utils)
