### PR TITLE
Added clarity to a note about linux limits

### DIFF
--- a/docs/source/starter/getting_started_guide.rst
+++ b/docs/source/starter/getting_started_guide.rst
@@ -711,8 +711,8 @@ With the local server still running:
 
    .. NOTE::
 
-     On Linux, the SDK only supports running in canvas mode.  Use the
-     command for canvas-debug below in order to run the app.
+     On Linux, the SDK only supports running in canvas mode. Use the command
+     for canvas-debug below in order to run the app on Linux browsers.
 
 6. Back in your browser, click on the *Play* button for your newly
    created project.  The page should list the file just created


### PR DESCRIPTION
I found the note at http://docs.turbulenz.com/starter/getting_started_guide.html#creating-a-turbulenz-application about Linux's canvas limitation to be ambiguous (was it the local server or the client). Knowing _now_ what it is makes it all very clear, but for people who are first seeing the docs it could be confusing for them as well. Explicit is better than implicit, so they say.
