### PR TITLE
Fixed an infinite loop bug in _transmitBodyType()

### DIFF
--- a/tslib/physics2ddevice.ts
+++ b/tslib/physics2ddevice.ts
@@ -12051,6 +12051,7 @@ class Physics2DWorld
                 var arb = arbiters[j];
                 if (arb._retired)
                 {
+                    j += 1;
                     continue;
                 }
 


### PR DESCRIPTION
When setting a body as static the "setAsStatic" method sometimes gets stuck in an infinite loop. This should fix the problem.
