### PR TITLE
Added interfaces for the different params parameters of the Physics2DDevice create methods

### DIFF
--- a/tslib/physics2ddevice.ts
+++ b/tslib/physics2ddevice.ts
@@ -7695,11 +7695,6 @@ class Physics2DBoxTreeBroadphase implements Physics2DBroadphase
         this.dynamicTree.finalize();
     }
 
-    validate(): void
-    {
-        this._validate();
-    }
-
     perform(lambda, thisObject)
     {
         this._validate();
@@ -9702,7 +9697,6 @@ interface Physics2DBroadphase
     update(handle, aabb, isStatic?: boolean): void;
     remove(handle): void;
     clear(callback, thisObject): void;
-    validate(): void;
     perform(lambda, thisObject): void;
 };
 


### PR DESCRIPTION
I have added interfaces for most of the create methods of the Physics2DDevice class (e.g. createPointConstraint) as was already done for some methods like createMaterial.

This improves development in Visual Studio as it enables auto completition for these methods.
